### PR TITLE
changed path of .git config

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var init = function() {
   var ini = require('ini');
   var uuid = require('uuid');
   try {
-    var config = ini.parse(fs.readFileSync('../gripid/.git/config','utf-8'));
+    var config = ini.parse(fs.readFileSync('./.git/config','utf-8'));
     var url = config['remote "origin"']['url']
   } catch (e) {
     url = '';


### PR DESCRIPTION
I was unable to use the module based on the way you described it in the instructions. I took a look at the source and I think you may have left a hardcoded a path on your system in the fuction that processes the .git config. I forked and removed the `gripid` portion of the path and it started working correctly.
